### PR TITLE
Rename package to digipolisgent/qa-drupal (2.x branch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For a website:
 
 ```json
 "grumphp": {
-    "config-default-path": "vendor/gent/qa-drupal/configs/grumphp-site.yml"
+    "config-default-path": "vendor/digipolisgent/qa-drupal/configs/grumphp-site.yml"
 }
 ```
 
@@ -32,9 +32,9 @@ For an extension:
 
 ```json
 "grumphp": {
-    "config-default-path": "vendor/gent/qa-drupal/configs/grumphp-extension.yml"
+    "config-default-path": "vendor/digipolisgent/qa-drupal/configs/grumphp-extension.yml"
 }
 ```
 
 Now install this package and its requirements by executing the following command:
-<pre><code>composer require --dev gent/qa-drupal</code></pre>
+<pre><code>composer require --dev digipolisgent/qa-drupal</code></pre>

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,18 @@
     "name": "digipolisgent/qa-drupal",
     "description": "Quality Assurance tools and configuration for Drupal websites and extensions.",
     "type": "library",
+    "authors": [
+        {
+            "name": "Van Assche Matthijs",
+            "email": "matthijs.vanassche@digipolis.gent",
+            "role": "developer"
+        },
+        {
+            "name": "Maarten Segers",
+            "email": "maarten.segers@digipolis.gent",
+            "role": "developer"
+        }
+    ],
     "autoload": {
         "psr-4": {
             "Gent\\QA\\Drupal\\": "src/"

--- a/configs/grumphp-extension.yml
+++ b/configs/grumphp-extension.yml
@@ -72,7 +72,7 @@ grumphp:
         - profile
     phpcs:
       standard:
-        - vendor/gent/qa-drupal/configs/phpcs.xml
+        - vendor/digipolisgent/qa-drupal/configs/phpcs.xml
       report_width: 120
       ignore_patterns:
         - node_modules/
@@ -86,7 +86,7 @@ grumphp:
         - yml
     phpmd:
       ruleset:
-        - vendor/gent/qa-drupal/configs/phpmd.xml
+        - vendor/digipolisgent/qa-drupal/configs/phpmd.xml
       triggered_by:
         - php
         - inc
@@ -95,7 +95,7 @@ grumphp:
         - theme
         - profile
     phpstan:
-      configuration: vendor/gent/qa-drupal/configs/phpstan-extension.neon
+      configuration: vendor/digipolisgent/qa-drupal/configs/phpstan-extension.neon
       level: 8
       triggered_by:
         - php
@@ -105,7 +105,7 @@ grumphp:
         - theme
         - profile
     phpunit:
-      config_file: vendor/gent/qa-drupal/configs/phpunit-extension.xml
+      config_file: vendor/digipolisgent/qa-drupal/configs/phpunit-extension.xml
     yamllint:
       ignore_patterns:
         - node_modules/

--- a/configs/grumphp-site.yml
+++ b/configs/grumphp-site.yml
@@ -82,7 +82,7 @@ grumphp:
         - profile
     phpcs:
       standard:
-        - vendor/gent/qa-drupal/configs/phpcs.xml
+        - vendor/digipolisgent/qa-drupal/configs/phpcs.xml
       report_width: 120
       whitelist_patterns:
         - "#^web/(modules|themes|profiles)/custom/#"
@@ -98,7 +98,7 @@ grumphp:
         - yml
     phpmd:
       ruleset:
-        - vendor/gent/qa-drupal/configs/phpmd.xml
+        - vendor/digipolisgent/qa-drupal/configs/phpmd.xml
       whitelist_patterns:
         - "#^web/(modules|themes|profiles)/custom/#"
       triggered_by:
@@ -109,7 +109,7 @@ grumphp:
         - theme
         - profile
     phpstan:
-      configuration: vendor/gent/qa-drupal/configs/phpstan-site.neon
+      configuration: vendor/digipolisgent/qa-drupal/configs/phpstan-site.neon
       level: 8
       force_patterns:
         - "#^web/(modules|themes|profiles)/custom/#"
@@ -123,7 +123,7 @@ grumphp:
         - theme
         - profile
     phpunit:
-      config_file: vendor/gent/qa-drupal/configs/phpunit-site.xml
+      config_file: vendor/digipolis/qa-drupal/configs/phpunit-site.xml
     yamllint:
       whitelist_patterns:
         - "#^(\\.[^/]+/)?[^/]+\\.yml$#"

--- a/configs/grumphp-site.yml
+++ b/configs/grumphp-site.yml
@@ -123,7 +123,7 @@ grumphp:
         - theme
         - profile
     phpunit:
-      config_file: vendor/digipolis/qa-drupal/configs/phpunit-site.xml
+      config_file: vendor/digipolisgent/qa-drupal/configs/phpunit-site.xml
     yamllint:
       whitelist_patterns:
         - "#^(\\.[^/]+/)?[^/]+\\.yml$#"


### PR DESCRIPTION
The namespace of the project has changed but the references are still pointing to the old namespace.