### PR TITLE
Fix code standards and run extension tests in isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,4 +167,11 @@ The files will be created as:
 - `phpmd.qa-drupal.xml` : PHP Mess Detector config file.
 - `phpunit.qa-drupal.xml` : PHPUnit config file.
 
-Use these files in the PHPStorm configuration.
+Configure the paths to these files in PHPStorm:
+
+* Editor > Inspections > PHP > Quality tools > PHP Mess Detector validation
+  Add `phpmd.qa-drupal.xml` to the "Custom rulesets".
+* Editor > Inspections > PHP > Quality tools > PHP_CodeSniffer validation
+  Set "Coding Standard" to "Custom" and set the path to `phpcs.qa-drupal.xml`.
+* Languages & Frameworks > PHP > Test Frameworks > Test Runner
+  Set "Default configuration file" to `phpunit.qa-drupal.xml`.

--- a/README.md
+++ b/README.md
@@ -1,24 +1,25 @@
-This package provides a set of Quality Assurance tools and configuration files for
-Drupal websites and extensions (modules, themes or profiles).
+# Quality Assurance - Drupal
 
+This package provides a set of Quality Assurance tools and configuration files
+for Drupal websites and extensions (modules, themes or profiles).
 
-# Requirements
+## Requirements
 
 * [Composer](https://getcomposer.org)
 
-
-# Versions
+## Versions
 
 | Package | Drupal |
 | ------- | ------ |
 | 1       | 8      |
 
+## Installation
 
-# Installation
+The installation depends on the type of project: website or Drupal module.
 
-First add one of following `grumphp` entries to the `extra` section of your `composer.json`.
+### Drupal website
 
-For a website:
+Add the `grumphp` entry to the `extra` section of your `composer.json`.
 
 ```json
 "grumphp": {
@@ -26,7 +27,15 @@ For a website:
 }
 ```
 
-For an extension:
+Add the qa-drupal package as dev requirement:
+
+```bash
+composer require --dev digipolisgent/qa-drupal:^1.0
+```
+
+### Drupal module
+
+Add the `grumphp` entry to the `extra` section of your `composer.json`.
 
 ```json
 "grumphp": {
@@ -34,23 +43,42 @@ For an extension:
 }
 ```
 
-Now install this package and its requirements by executing execute following command:
-<pre><code>composer require --dev digipolisgent/qa-drupal</code></pre>
+Add the qa-drupal package as dev requirement:
 
+```bash
+composer require --dev digipolisgent/qa-drupal:^1.0
+```
 
-# Configuration
+**NOTE** : phpstan needs a Drupal project in a `drupal` directory next to the
+module directory. You can do this by running following command in the directory
+above the module directory:
 
-## General
+```bash
+composer create-project "drupal/recommended-project:8.9.x-dev" ./drupal --prefer-dist
+```
 
-If required you can extend or override the provided configuration file of a task.
-Simply create the matching configuration file in the root of your project.
+You can replace the drupal version by 8.8.x-dev, 9.0.x-dev, 9.1.x-dev, ...
+
+## Configuration
+
+### General
+
+If required you can extend or override the provided configuration file of a
+task. Simply create the matching configuration file in the root of your project.
 
 For example, to override the provided `phpcs.xml` file you can either create a
-`phpcs.xml` or `phpcs.local.xml` file. Note that the latter one should only be
-used for changes that shouldn't be comitted.
+`phpcs.xml` or `phpcs.local.xml` file.
 
-Yaml and Neon files will extend (merged into) the provided configuration file by default.
-Create a `.env` or `.env.local` file and add following contents to change this behaviour:
+Note that the `.local.` files should only be used for changes that shouldn't be
+committed. Exclude them in `.gitignore`:
+
+```gitignore
+/*.local.*
+```
+
+Yaml and Neon files will extend (merged into) the provided configuration file by
+default. Create a `.env` or `.env.local` file and add following contents to
+change this behaviour:
 
 ```
 [FILENAME]_SKIP_[TYPE]=1
@@ -60,15 +88,17 @@ Wherein `[FILENAME]` matches the configuration filename and `[TYPE]` is either:
 
 - `LOCAL` to skip for example your `phpstan.local.neon` file.
 - `PROJECT` to skip for example your `phpstan.neon` file.
-- `PACKAGE_TYPE` to skip for example the provided `phpstan-extension.neon` or `phpstan-site.neon` file.
+- `PACKAGE_TYPE` to skip for example the provided `phpstan-extension.neon` or
+  `phpstan-site.neon` file.
 - `PACKAGE_GLOBAL` to skip for example the provided `phpstan.neon` file.
 
-Other file types cannot be merged and will just override all other less specific files.
+Other file types cannot be merged and will just override all other less specific
+files.
 
+### PHPStan in deprecations only mode
 
-## PHPStan in deprecations only mode
-
-Create a `phpstan.neon` file and add following contents to ignore everything except deprecations.
+Create a `phpstan.neon` file and add following contents to ignore everything
+except deprecations:
 
 ```
 parameters:
@@ -76,3 +106,65 @@ parameters:
   ignoreErrors:
     - '#^(?:(?!deprecated).)*$#'
 ```
+
+### Ignore automatically created config files
+
+Some GrumPHP tasks require a config file. These are automatically creacted, from
+the examples within vendor/qa-drupal/config or by the project specific files
+within your website or drupal module root directory. The generated files are
+also stored in the same website/module root. You can recognize these files by
+the `.qa-drupal.` suffix.
+
+**These files should not be committed!** Add them to the `.gitignore` file:
+
+```gitignore
+/*.qa-drupal.*
+```
+
+### Ignore PHPUnit build files
+
+When the PHPUnit task runs, coverage report files are stored into the `build`
+directory located in the root of your website/project. Add this file to the
+`.gitignore` file:
+
+```gitignore
+/build
+/.phpunit.result.cache
+```
+
+### Run PHPUnit locally without coverage
+
+Running PHPUnit with coverage report is time consuming. You can locally speed up
+PHPUnit by copying the generated `phpunit.qa-drupal.xml` file to
+`phpunit.local.xml` and remove the `<logging>` section from it.
+
+## Run GrumPHP
+
+GrumPHP will automatically run all tasks on the changed code on git commit and
+push.
+
+You can run all tasks at once:
+
+```bash
+vendor/bin/grumphp
+```
+
+Or you can run one or more specific tasks manually by running:
+
+```bash
+vendor/bin/grumphp --tasks phpcs,phpmd
+vendor/bin/grumphp --tasks phpunit
+```
+
+## PHPStorm
+
+PHPStorm requires config files for PHP_CodeSniffer, PHP Mess Detector & PhpUnit.
+Run the grumphp command at least once (successfully) to generate these files.
+
+The files will be created as:
+
+- `phpcs.qa-drupal.xml` : PHP_CodeSniffer config file.
+- `phpmd.qa-drupal.xml` : PHP Mess Detector config file.
+- `phpunit.qa-drupal.xml` : PHPUnit config file.
+
+Use these files in the PHPStorm configuration.

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         }
     },
     "require": {
+        "php": "^7.2",
         "drupal/coder": "^8.3",
         "drupal/core": "^8.9",
         "drupal/drupal-extension": "^4.1",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     },
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
         "drupal/coder": "^8.3",
         "drupal/core": "^8.9",
         "drupal/drupal-extension": "^4.1",

--- a/configs/grumphp-extension.yml
+++ b/configs/grumphp-extension.yml
@@ -1,4 +1,7 @@
 grumphp:
+  hooks_dir: ~
+  hooks_preset: local
+  process_timeout: 3600
   hide_circumvention_tip: true
   ascii:
     failed: ~
@@ -37,75 +40,85 @@ grumphp:
         - "\\$_[A-Z_]+\\["
       regexp_type: E
       triggered_by:
-        - php
         - inc
         - install
         - module
-        - theme
+        - php
         - profile
+        - theme
     git_branch_name:
       whitelist:
-        - "#^\\d+\\(.\\d+)?\\.x|feature/([A-Z][A-Z0-9]+-\\d+|[a-z][a-z0-9]*(-[a-z0-9]+)*)$#"
+        - "#^\\d+(.\\d+)?\\.x|master|develop|feature/([A-Z][A-Z0-9]+-\\d+|[a-z][a-z0-9]*(-[a-z0-9]+)*)$#"
     git_commit_message:
-      enforce_no_subject_trailing_period: false
-      max_body_width: 80
-      max_subject_width: 80
       matchers:
-        - "/^([A-Z][A-Z0-9]+-\\d+(, [A-Z][A-Z0-9]+-\\d+)*: )?(Add|Change|Fix|Update|Remove) /"
+        - "/^([A-Z][A-Z0-9]+-\\d+(, [A-Z][A-Z0-9]+-\\d+)*: )?(Add|Change|Fix|Update|Remove|Refactor) /"
       case_insensitive: false
     phpcpd:
       exclude:
         - tests
         - vendor
+        - "*.api.php"
+        - "*Test.php"
+        - "*TestBase.php"
+        - "*TestCase.php"
       min_lines: 10
       triggered_by:
-        - php
         - inc
         - install
         - module
-        - theme
+        - php
         - profile
+        - theme
     phpcs:
+      severity: 6
       standard:
-        - .phpcs.qa-drupal.xml
+        - phpcs.qa-drupal.xml
       report_width: 120
       ignore_patterns:
+        - build/
         - node_modules/
-        - "#^vendor/#"
+        - vendor/
+        - "*.md"
       triggered_by:
-        - php
+        - css
         - inc
         - install
+        - js
         - module
-        - theme
+        - php
         - profile
+        - theme
+        - twig
         - yml
     phpmd:
       ruleset:
-        - .phpmd.qa-drupal.xml
+        - phpmd.qa-drupal.xml
       exclude:
-        - vendor
+        - "build/*"
+        - "tests/*"
+        - "vendor/*"
       triggered_by:
-        - php
         - inc
         - install
         - module
-        - theme
+        - php
         - profile
+        - theme
     phpstan:
-      configuration: .phpstan.qa-drupal.neon
+      configuration: phpstan.qa-drupal.neon
+      level: 4
       ignore_patterns:
         - "#(^|/)tests/#"
         - "#^vendor/#"
       triggered_by:
-        - php
         - inc
         - install
         - module
-        - theme
+        - php
         - profile
+        - theme
     phpunit:
-      config_file: .phpunit.qa-drupal.xml
+      config_file: phpunit.qa-drupal.xml
     yamllint:
       ignore_patterns:
         - node_modules/
@@ -116,5 +129,3 @@ services:
     class: Digipolisgent\QA\Drupal\GrumPHP\EventListener\TaskEventListener
     tags:
       - { name: grumphp.event_listener, event: grumphp.task.run, method: createTaskConfig, priority: 100 }
-      - { name: grumphp.event_listener, event: grumphp.task.complete, method: removeTaskConfig }
-      - { name: grumphp.event_listener, event: grumphp.task.failed, method: removeTaskConfig }

--- a/configs/grumphp-extension.yml
+++ b/configs/grumphp-extension.yml
@@ -102,7 +102,6 @@ grumphp:
         - theme
     phpstan:
       configuration: phpstan.qa-drupal.neon
-      level: 4
       ignore_patterns:
         - "#(^|/)tests/#"
         - "#^vendor/#"

--- a/configs/grumphp-extension.yml
+++ b/configs/grumphp-extension.yml
@@ -1,6 +1,4 @@
 grumphp:
-  hooks_dir: ~
-  hooks_preset: local
   process_timeout: 3600
   hide_circumvention_tip: true
   ascii:
@@ -70,7 +68,6 @@ grumphp:
         - profile
         - theme
     phpcs:
-      severity: 6
       standard:
         - phpcs.qa-drupal.xml
       report_width: 120

--- a/configs/grumphp-extension.yml
+++ b/configs/grumphp-extension.yml
@@ -46,7 +46,7 @@ grumphp:
         - theme
     git_branch_name:
       whitelist:
-        - "#^\\d+(.\\d+)?\\.x|master|develop|feature/([A-Z][A-Z0-9]+-\\d+|[a-z][a-z0-9]*(-[a-z0-9]+)*)$#"
+        - "#^\\d+(\\.\\d+)?\\.x|feature/([A-Z][A-Z0-9]+-\\d+|[a-z][a-z0-9]*(-[a-z0-9]+)*)$#"
     git_commit_message:
       matchers:
         - "/^([A-Z][A-Z0-9]+-\\d+(, [A-Z][A-Z0-9]+-\\d+)*: )?(Add|Change|Fix|Update|Remove|Refactor) /"
@@ -75,7 +75,6 @@ grumphp:
         - build/
         - node_modules/
         - vendor/
-        - "*.md"
       triggered_by:
         - css
         - inc

--- a/configs/grumphp-site.yml
+++ b/configs/grumphp-site.yml
@@ -88,7 +88,6 @@ grumphp:
         - build/
         - node_modules/
         - sassdocs/
-        - "*.md"
       triggered_by:
         - css
         - inc

--- a/configs/grumphp-site.yml
+++ b/configs/grumphp-site.yml
@@ -31,7 +31,7 @@ grumphp:
         - phpunit
   tasks:
     behat:
-      config: qa-drupal.behat.yml
+      config: behat.qa-drupal.yml
     composer:
       no_check_publish: true
     git_blacklist:

--- a/configs/grumphp-site.yml
+++ b/configs/grumphp-site.yml
@@ -1,4 +1,8 @@
 grumphp:
+  hooks_dir: ~
+  hooks_preset: local
+  stop_on_failure: false
+  process_timeout: 3600
   hide_circumvention_tip: true
   ascii:
     failed: ~
@@ -30,7 +34,7 @@ grumphp:
         - phpunit
   tasks:
     behat:
-      config: .behat.qa-drupal.yml
+      config: qa-drupal.behat.yml
     composer:
       no_check_publish: true
     git_blacklist:
@@ -43,21 +47,18 @@ grumphp:
       whitelist_patterns:
         - "#^web/(modules|themes|profiles)/custom/#"
       triggered_by:
-        - php
         - inc
         - install
         - module
-        - theme
+        - php
         - profile
+        - theme
     git_branch_name:
       whitelist:
-        - "#^develop|feature/([A-Z][A-Z0-9]+-\\d+|[a-z][a-z0-9]*(-[a-z0-9]+)*)|(release|hotfix)/\\d+(\\.\\d+){2}$#"
+        - "#^master|develop|feature/([A-Z][A-Z0-9]+-\\d+|[a-z][a-z0-9]*(-[a-z0-9]+)*)|(release|hotfix)/\\d+(\\.\\d+){2}$#"
     git_commit_message:
-      enforce_no_subject_trailing_period: false
-      max_body_width: 80
-      max_subject_width: 80
       matchers:
-        - "/^([A-Z][A-Z0-9]+-\\d+(, [A-Z][A-Z0-9]+-\\d+)*: )?(Add|Change|Fix|Update|Remove) /"
+        - "/^([A-Z][A-Z0-9]+-\\d+(, [A-Z][A-Z0-9]+-\\d+)*: )?(Add|Change|Fix|Update|Remove|Refactor) /"
       case_insensitive: false
     phpcpd:
       directory:
@@ -68,58 +69,68 @@ grumphp:
         - web/*/contrib
         - web/modules/custom/*/tests
         - web/sites
+        - "*.api.php"
+        - "*Test.php"
+        - "*TestBase.php"
+        - "*TestCase.php"
       min_lines: 10
       triggered_by:
-        - php
         - inc
         - install
         - module
-        - theme
+        - php
         - profile
+        - theme
     phpcs:
       standard:
-        - .phpcs.qa-drupal.xml
+        - phpcs.qa-drupal.xml
       report_width: 120
       whitelist_patterns:
         - "#^web/(modules|themes|profiles)/custom/#"
       ignore_patterns:
+        - build/
         - node_modules/
+        - sassdocs/
+        - "*.md"
       triggered_by:
-        - php
+        - css
         - inc
         - install
+        - js
         - module
-        - theme
+        - php
         - profile
+        - theme
+        - twig
         - yml
     phpmd:
       ruleset:
-        - .phpmd.qa-drupal.xml
+        - phpmd.qa-drupal.xml
       whitelist_patterns:
         - "#^web/(modules|themes|profiles)/custom/#"
       triggered_by:
-        - php
         - inc
         - install
         - module
-        - theme
+        - php
         - profile
+        - theme
     phpstan:
-      configuration: .phpstan.qa-drupal.neon
+      configuration: phpstan.qa-drupal.neon
       level: 4
       force_patterns:
         - "#^web/(modules|themes|profiles)/custom/((?:(?!tests)[^/])+/)+[^/]+$#"
       ignore_patterns:
         - "#.*#"
       triggered_by:
-        - php
         - inc
         - install
         - module
-        - theme
+        - php
         - profile
+        - theme
     phpunit:
-      config_file: .phpunit.qa-drupal.xml
+      config_file: phpunit.qa-drupal.xml
     yamllint:
       whitelist_patterns:
         - "#^(\\.[^/]+/)?[^/]+\\.yml$#"
@@ -133,5 +144,3 @@ services:
     class: Digipolisgent\QA\Drupal\GrumPHP\EventListener\TaskEventListener
     tags:
       - { name: grumphp.event_listener, event: grumphp.task.run, method: createTaskConfig, priority: 100 }
-      - { name: grumphp.event_listener, event: grumphp.task.complete, method: removeTaskConfig }
-      - { name: grumphp.event_listener, event: grumphp.task.failed, method: removeTaskConfig }

--- a/configs/grumphp-site.yml
+++ b/configs/grumphp-site.yml
@@ -1,7 +1,4 @@
 grumphp:
-  hooks_dir: ~
-  hooks_preset: local
-  stop_on_failure: false
   process_timeout: 3600
   hide_circumvention_tip: true
   ascii:

--- a/configs/phpcs.xml
+++ b/configs/phpcs.xml
@@ -2,11 +2,6 @@
 <ruleset>
   <description>PHP CodeSniffer ruleset for Drupal.</description>
 
-  <!-- Exclude unsupported file types. -->
-  <exclude-pattern>*.gif</exclude-pattern>
-  <exclude-pattern>*.less</exclude-pattern>
-  <exclude-pattern>*.png</exclude-pattern>
-
   <!-- Minified files don't have to comply with coding standards. -->
   <exclude-pattern>*.min.css</exclude-pattern>
   <exclude-pattern>*.min.js</exclude-pattern>

--- a/configs/phpcs.xml
+++ b/configs/phpcs.xml
@@ -2,23 +2,18 @@
 <ruleset>
   <description>PHP CodeSniffer ruleset for Drupal.</description>
 
-  <rule ref="vendor/drupal/coder/coder_sniffer/Drupal"  />
+  <!-- Exclude unsupported file types. -->
+  <exclude-pattern>*.gif</exclude-pattern>
+  <exclude-pattern>*.less</exclude-pattern>
+  <exclude-pattern>*.png</exclude-pattern>
 
-  <rule ref="vendor/drupal/coder/coder_sniffer/DrupalPractice">
-    <exclude name="DrupalPractice.Yaml.RoutingAccess.OpenCallback" />
-    <exclude name="DrupalPractice.FunctionDefinitions.AccessHookMenu" />
-  </rule>
+  <!-- Minified files don't have to comply with coding standards. -->
+  <exclude-pattern>*.min.css</exclude-pattern>
+  <exclude-pattern>*.min.js</exclude-pattern>
 
-  <rule ref="Drupal.Files.LineLength">
-    <properties>
-      <property name="lineLimit" value="120" />
-      <property name="absoluteLineLimit" value="150" />
-    </properties>
-  </rule>
+  <rule ref="./vendor/drupal/coder/coder_sniffer/Drupal" />
+  <rule ref="./vendor/drupal/coder/coder_sniffer/DrupalPractice"></rule>
 
-  <rule ref="Drupal.Arrays.Array">
-    <properties>
-      <property name="lineLimit" value="120" />
-    </properties>
-  </rule>
+  <!-- PSR-12 sniffs -->
+  <rule ref="PSR12.Files.DeclareStatement" />
 </ruleset>

--- a/configs/phpmd.xml
+++ b/configs/phpmd.xml
@@ -2,66 +2,42 @@
 <ruleset name="Drupal ruleset"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0
+                http://pmd.sourceforge.net/ruleset_2_0_0.xsd"
+         xsi:noNamespaceSchemaLocation="
+                http://pmd.sf.net/ruleset_xml_schema.xsd">
 
-  <description>PMD ruleset for Drupal.</description>
+  <description>
+    Ruleset for PHPMD analysis of Drupal projects. Excludes coding issues
+    handled better by PHPCS and rules which have too many false positives
+    in a typical Drupal codebase.
+  </description>
 
   <rule ref="rulesets/cleancode.xml">
-    <exclude name="BooleanArgumentFlag" />
-    <exclude name="ElseExpression" />
-    <exclude name="IfStatementAssignment" />
+    <!--
+      Validated by PHPCS and is in conflict with the DrupalPractices sniffs.
+    -->
     <exclude name="MissingImport" />
+    <!--
+      PHPMD is not smart enough to see the difference between static access and
+      named constructors.
+    -->
     <exclude name="StaticAccess" />
   </rule>
 
-  <rule ref="rulesets/codesize.xml">
-    <exclude name="CyclomaticComplexity" />
-    <exclude name="ExcessiveClassComplexity" />
-    <exclude name="ExcessiveMethodLength" />
-    <exclude name="ExcessiveParameterList" />
-    <exclude name="NPathComplexity" />
-    <exclude name="TooManyMethods" />
-    <exclude name="TooManyPublicMethods" />
-  </rule>
-
-  <rule ref="rulesets/codesize.xml/CyclomaticComplexity">
-    <properties>
-      <property name="reportLevel" value="20" />
-    </properties>
-  </rule>
-
-  <rule ref="rulesets/codesize.xml/ExcessiveMethodLength">
+  <rule ref="rulesets/codesize.xml" />
+  <!--rule ref="rulesets/codesize.xml/ExcessiveMethodLength">
     <properties>
       <property name="minimum" value="250" />
     </properties>
-  </rule>
+  </rule-->
 
-  <rule ref="rulesets/codesize.xml/TooManyPublicMethods">
-    <properties>
-      <property name="maxmethods" value="15" />
-      <property name="ignorepattern" value="(^(set|get|is))i" />
-    </properties>
-  </rule>
+  <rule ref="rulesets/design.xml" />
 
-  <rule ref="rulesets/design.xml">
-    <exclude name="CouplingBetweenObjects" />
-  </rule>
-
-  <rule ref="rulesets/naming.xml">
-    <exclude name="ShortVariable" />
-    <exclude name="LongVariable" />
-  </rule>
-
+  <rule ref="rulesets/naming.xml" />
   <rule ref="rulesets/naming.xml/ShortVariable">
     <properties>
-      <property name="minimum" value="2" />
       <property name="exceptions" value="id" />
-    </properties>
-  </rule>
-
-  <rule ref="rulesets/naming.xml/LongVariable">
-    <properties>
-      <property name="maximum" value="30" />
     </properties>
   </rule>
 

--- a/configs/phpstan.neon
+++ b/configs/phpstan.neon
@@ -3,6 +3,7 @@ includes:
   - vendor/phpstan/phpstan-deprecation-rules/rules.neon
 
 parameters:
+  level: 4
   tipsOfTheDay: false
   reportUnmatchedIgnoredErrors: false
   ignoreErrors:

--- a/configs/phpstan.neon
+++ b/configs/phpstan.neon
@@ -3,7 +3,6 @@ includes:
   - vendor/phpstan/phpstan-deprecation-rules/rules.neon
 
 parameters:
-  level: 4
   tipsOfTheDay: false
   reportUnmatchedIgnoredErrors: false
   ignoreErrors:

--- a/configs/phpstan.neon
+++ b/configs/phpstan.neon
@@ -14,4 +14,4 @@ parameters:
   excludes_analyse:
     - '*/node_modules/*'
   scanDirectories:
-      - %currentWorkingDirectory%
+    - %currentWorkingDirectory%

--- a/configs/phpstan.neon
+++ b/configs/phpstan.neon
@@ -13,3 +13,5 @@ parameters:
     - '#Access to an undefined property Drupal\\Core\\TypedData\\TypedDataInterface::\$#'
   excludes_analyse:
     - '*/node_modules/*'
+  scanDirectories:
+      - %currentWorkingDirectory%

--- a/configs/phpunit-extension.xml
+++ b/configs/phpunit-extension.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- TODO set checkForUnintentionallyCoveredCode="true" once https://www.drupal.org/node/2626832 is resolved. -->
-<phpunit bootstrap="../drupal/core/tests/bootstrap.php"
+<phpunit bootstrap="vendor/digipolisgent/qa-drupal/src/PHPUnit/Extension/bootstrap.php"
          printerClass="Drupal\Tests\Listeners\HtmlOutputPrinter"
          colors="true"
          beStrictAboutTestsThatDoNotTestAnything="true"

--- a/src/Behat/Context/AccessContext.php
+++ b/src/Behat/Context/AccessContext.php
@@ -14,7 +14,7 @@ class AccessContext extends RawDrupalContext
      *
      * @Then I should have access to the page
      */
-    public function assertAccess()
+    public function assertAccess(): void
     {
         $this->assertSession()->statusCodeEquals(200);
     }
@@ -24,7 +24,7 @@ class AccessContext extends RawDrupalContext
      *
      * @Then I should get an access denied error
      */
-    public function assertAccessDenied()
+    public function assertAccessDenied(): void
     {
         $this->assertSession()->statusCodeEquals(403);
     }

--- a/src/Behat/Context/DebugContext.php
+++ b/src/Behat/Context/DebugContext.php
@@ -43,10 +43,14 @@ class DebugContext extends RawMinkContext
     /**
      * Class constructor.
      *
-     * @param string $path The path were to save the dumps.
-     * @param bool $html Wether to dump the HTML.
-     * @param bool $screenshot Wether to create a screenshot.
-     * @param bool $allSteps Set to true to dump all steps.
+     * @param string $path
+     *   The path were to save the dumps.
+     * @param bool $html
+     *   Whether to dump the HTML.
+     * @param bool $screenshot
+     *   Whether to create a screenshot.
+     * @param bool $allSteps
+     *   Set to true to dump all steps.
      */
     public function __construct($path, $html = true, $screenshot = true, $all_steps = false)
     {
@@ -66,7 +70,7 @@ class DebugContext extends RawMinkContext
      *
      * @param \Behat\Behat\Hook\Scope\AfterStepScope $afterStepScope
      */
-    public function debugDumpAfterStep(AfterStepScope $afterStepScope)
+    public function debugDumpAfterStep(AfterStepScope $afterStepScope): void
     {
         if (TestResult::FAILED === $afterStepScope->getTestResult()->getResultCode()) {
             $this->dumpAll();
@@ -85,7 +89,7 @@ class DebugContext extends RawMinkContext
      *
      * @Then (I )put a breakpoint
      */
-    public function iPutABreakpoint()
+    public function iPutABreakpoint(): void
     {
         fwrite(STDOUT, "\033[s    \033[93m[Breakpoint] Press \033[1;93m[RETURN]\033[0;93m to continue...\033[0m");
         while (fgets(STDIN, 1024) === '') {
@@ -98,7 +102,7 @@ class DebugContext extends RawMinkContext
      *
      * @When I save a HTML dump
      */
-    public function iSaveAHtmlDump()
+    public function iSaveAHtmlDump(): void
     {
         $fileName = $this->getFileName() . '-forced.html';
         $this->dumpHtml($fileName);
@@ -109,7 +113,7 @@ class DebugContext extends RawMinkContext
      *
      * @When I take a screenshot
      */
-    public function iTakeAScreenShot()
+    public function iTakeAScreenShot(): void
     {
         $fileName = $this->getFileName() . '-forced.png';
         $this->dumpScreenshot($fileName);
@@ -120,7 +124,7 @@ class DebugContext extends RawMinkContext
      *
      * @param $message
      */
-    public function printDebug($message)
+    public function printDebug($message): void
     {
         echo $message;
     }
@@ -128,7 +132,7 @@ class DebugContext extends RawMinkContext
     /**
      * Wrapper to dump in all possible and enabled formats.
      */
-    protected function dumpAll()
+    protected function dumpAll(): void
     {
         $fileName = $this->getFileName();
 
@@ -147,7 +151,7 @@ class DebugContext extends RawMinkContext
      * @param string $filename
      *   The filename to save the HTML to.
      */
-    protected function dumpHtml($filename)
+    protected function dumpHtml($filename): void
     {
         if (!$filename = $this->getFilePath($filename)) {
             return;
@@ -177,7 +181,7 @@ class DebugContext extends RawMinkContext
      * @param string $filename
      *   The screenshot filename.
      */
-    protected function dumpScreenshot($filename)
+    protected function dumpScreenshot($filename): void
     {
         if (!$filename = $this->getFilePath($filename)) {
             return;
@@ -190,7 +194,7 @@ class DebugContext extends RawMinkContext
         }
 
         $this->saveScreenshot($filename, $this->dumpDirectory);
-        $this->printDebug('Screenshot saved to: file://'. $filename);
+        $this->printDebug('Screenshot saved to: file://' . $filename);
     }
 
     /**
@@ -199,7 +203,7 @@ class DebugContext extends RawMinkContext
      * @return string
      *   The file name.
      */
-    protected function getFileName()
+    protected function getFileName(): string
     {
         return date('YmdHis') . '_' . uniqid('', true);
     }
@@ -213,7 +217,7 @@ class DebugContext extends RawMinkContext
      * @return string|false
      *   The file path of false if the dump path doesn't exist.
      */
-    protected function getFilePath($filename)
+    protected function getFilePath($filename): ?string
     {
         if (!$this->dumpDirectory) {
             return false;

--- a/src/Behat/Context/SelectorContext.php
+++ b/src/Behat/Context/SelectorContext.php
@@ -19,7 +19,7 @@ class SelectorContext extends RawDrupalContext
      *
      * @throws \Exception
      */
-    public function assertElementText($text, $selector)
+    public function assertElementText($text, $selector): void
     {
         $page = $this->getSession()->getPage();
         $elements = $page->findAll('css', $selector);
@@ -43,7 +43,7 @@ class SelectorContext extends RawDrupalContext
      *
      * @throws \Exception
      */
-    public function notAssertElementText($text, $selector)
+    public function notAssertElementText($text, $selector): void
     {
         $page = $this->getSession()->getPage();
         $elements = $page->findAll('css', $selector);

--- a/src/Behat/Context/UriContext.php
+++ b/src/Behat/Context/UriContext.php
@@ -20,7 +20,7 @@ class UriContext extends RawDrupalContext
      *
      * @Then the :link link should point to :uri
      */
-    public function assertLinkUri($link, $uri)
+    public function assertLinkUri($link, $uri): void
     {
         $link_clean = str_replace('\\"', '"', $link);
         $link_found = $this
@@ -48,14 +48,15 @@ class UriContext extends RawDrupalContext
      *
      * @then the current URI should be :uri
      */
-    public function assertCurrentUri($uri)
+    public function assertCurrentUri($uri): void
     {
         $current_uri = $this->getCurrentUri();
 
         Assert::assertEquals(
             $uri,
             $current_uri,
-            sprintf('The uri "%s" is not equal to current uri "%uri".',
+            sprintf(
+                'The uri "%s" is not equal to current uri "%uri".',
                 $uri,
                 $current_uri
             )
@@ -67,7 +68,7 @@ class UriContext extends RawDrupalContext
      *
      * @return string The base URL of the site.
      */
-    public function getBaseUrl()
+    public function getBaseUrl(): string
     {
         return $this->getMinkParameter('base_url');
     }
@@ -77,7 +78,7 @@ class UriContext extends RawDrupalContext
      *
      * @return string The URL of the current page.
      */
-    public function getCurrentUrl()
+    public function getCurrentUrl(): string
     {
         return $this->getSession()->getCurrentUrl();
     }
@@ -87,7 +88,7 @@ class UriContext extends RawDrupalContext
      *
      * @return string The current URI.
      */
-    public function getCurrentUri()
+    public function getCurrentUri(): string
     {
         return str_replace(
             rtrim($this->getBaseUrl(), '/'),

--- a/src/GrumPHP/EventListener/TaskEventListener.php
+++ b/src/GrumPHP/EventListener/TaskEventListener.php
@@ -140,26 +140,6 @@ final class TaskEventListener
     }
 
     /**
-     * Remove the task configuration file.
-     *
-     * @param \GrumPHP\Event\TaskEvent $event
-     *   The GrumPHP task event.
-     */
-    public function removeTaskConfig(TaskEvent $event): void
-    {
-        $info = $this->getTaskConfigFileInfo($event->getTask());
-        if (!$info) {
-            return;
-        }
-
-        $filesystem = new Filesystem();
-
-        if ($filesystem->exists($info['grumphp'])) {
-            $filesystem->remove($info['grumphp']);
-        }
-    }
-
-    /**
      * Get some information about the task configuration file.
      *
      * @param \GrumPHP\Task\TaskInterface $task

--- a/src/GrumPHP/EventListener/TaskEventListener.php
+++ b/src/GrumPHP/EventListener/TaskEventListener.php
@@ -21,16 +21,49 @@ final class TaskEventListener
     /**
      * Configuration file types.
      */
-    protected const FILETYPE_XML = 'xml';
-    protected const FILETYPE_YAML = 'yaml';
-    protected const FILETYPE_NEON = 'neon';
+    private const FILETYPE_XML = 'xml';
+    private const FILETYPE_YAML = 'yaml';
+    private const FILETYPE_NEON = 'neon';
 
     /**
      * Indicates whether the project is an extension.
      *
      * @var bool
      */
-    protected $isExtension;
+    private $isExtension;
+
+    /**
+     * Mapping of task types and their configuration files.
+     *
+     * @var array
+     */
+    private $taskInfo = [
+        Behat::class => [
+            'filename' => 'behat',
+            'extension' => 'yml',
+            'type' => self::FILETYPE_YAML,
+        ],
+        Phpcs::class => [
+            'filename' => 'phpcs',
+            'extension' => 'xml',
+            'type' => self::FILETYPE_XML,
+        ],
+        PhpMd::class => [
+            'filename' => 'phpmd',
+            'extension' => 'xml',
+            'type' => self::FILETYPE_XML,
+        ],
+        PhpStan::class => [
+            'filename' => 'phpstan',
+            'extension' => 'neon',
+            'type' => self::FILETYPE_NEON,
+        ],
+        Phpunit::class => [
+            'filename' => 'phpunit',
+            'extension' => 'xml',
+            'type' => self::FILETYPE_XML,
+        ],
+    ];
 
     /**
      * Create the task configuration file.
@@ -138,51 +171,17 @@ final class TaskEventListener
      */
     private function getTaskConfigFileInfo(TaskInterface $task): ?array
     {
-        $info = null;
-
-        if ($task instanceof Behat) {
-            $info = [
-                'filename' => 'behat',
-                'extension' => 'yml',
-                'type' => self::FILETYPE_YAML,
-            ];
-        }
-        if ($task instanceof Phpcs) {
-            $info = [
-                'filename' => 'phpcs',
-                'extension' => 'xml',
-                'type' => self::FILETYPE_XML,
-            ];
-        }
-        if ($task instanceof PhpMd) {
-            $info = [
-                'filename' => 'phpmd',
-                'extension' => 'xml',
-                'type' => self::FILETYPE_XML,
-            ];
-        }
-        if ($task instanceof PhpStan) {
-            $info = [
-                'filename' => 'phpstan',
-                'extension' => 'neon',
-                'type' => self::FILETYPE_NEON,
-            ];
-        }
-        if ($task instanceof Phpunit) {
-            $info = [
-                'filename' => 'phpunit',
-                'extension' => 'xml',
-                'type' => self::FILETYPE_XML,
-            ];
+        $taskClass = get_class($task);
+        if (empty($this->taskInfo[$taskClass])) {
+            return null;
         }
 
-        if ($info) {
-            $info['grumphp'] = sprintf(
-                '%s.qa-drupal.%s',
-                $info['filename'],
-                $info['extension']
-            );
-        }
+        $info = $this->taskInfo[$taskClass];
+        $info['grumphp'] = sprintf(
+            '%s.qa-drupal.%s',
+            $info['filename'],
+            $info['extension']
+        );
 
         return $info;
     }

--- a/src/GrumPHP/EventListener/TaskEventListener.php
+++ b/src/GrumPHP/EventListener/TaskEventListener.php
@@ -16,7 +16,7 @@ use Symfony\Component\Yaml\Yaml;
 /**
  * Listener for GrumPHP task events.
  */
-class TaskEventListener
+final class TaskEventListener
 {
     /**
      * Configuration file types.
@@ -37,83 +37,106 @@ class TaskEventListener
      *
      * @param TaskEvent $event The GrumPHP task event.
      */
-    public function createTaskConfig(TaskEvent $event)
+    public function createTaskConfig(TaskEvent $event): void
     {
-        if (!$info = $this->getTaskConfigFileInfo($event->getTask())) {
+        $info = $this->getTaskConfigFileInfo($event->getTask());
+        if (!$info) {
             return;
         }
 
         // Candidate configuration files.
-        $key_prefix = strtoupper($info['filename']) . '_SKIP_';
-        $type_suffix = ($this->isExtension() ? 'extension' : 'site');
-        $package_path = __DIR__ . '/../../../configs/';
+        $keyPrefix = strtoupper($info['filename']) . '_SKIP_';
+        $typeSuffix = ($this->isExtension() ? 'extension' : 'site');
+        $packagePath = __DIR__ . '/../../../configs/';
 
         $candidates = [
-            $key_prefix . 'LOCAL' => $info['filename'] . '.local.' . $info['extension'],
-            $key_prefix . 'PROJECT' => $info['filename'] . '.' . $info['extension'],
-            $key_prefix . 'PACKAGE_TYPE' => $package_path . $info['filename'] . '-' . $type_suffix . '.' . $info['extension'],
-            $key_prefix . 'PACKAGE_GLOBAL' => $package_path . $info['filename'] . '.' . $info['extension'],
+            $keyPrefix . 'LOCAL' => sprintf(
+                '%s.local.%s',
+                $info['filename'],
+                $info['extension']
+            ),
+            $keyPrefix . 'PROJECT' => sprintf(
+                '%s.%s',
+                $info['filename'],
+                $info['extension']
+            ),
+            $keyPrefix . 'PACKAGE_TYPE' => sprintf(
+                '%s%s-%s.%s',
+                $packagePath,
+                $info['filename'],
+                $typeSuffix,
+                $info['extension']
+            ),
+            $keyPrefix . 'PACKAGE_GLOBAL' => sprintf(
+                '%s%s.%s',
+                $packagePath,
+                $info['filename'],
+                $info['extension']
+            ),
         ];
 
         // Search for the candidates and merge or copy them.
-        $fs = new Filesystem();
-        $data_merged = NULL;
+        $filesystem = new Filesystem();
+        $dataMerged = null;
 
         foreach ($candidates as $env_var => $file) {
             // Ignore if configured to skip or if the file is missing.
-            if (!empty($_SERVER[$env_var]) || !$fs->exists($file)) {
+            if (!empty($_SERVER[$env_var]) || !$filesystem->exists($file)) {
                 continue;
             }
 
             // Read and parse the configuration file.
             $data = $this->readTaskConfigFile($info['type'], $file);
 
-            if ($data === FALSE) {
+            if ($data === false) {
                 // Just copy it if not readable.
-                $fs->copy($file, $info['grumphp']);
+                $filesystem->copy($file, $info['grumphp']);
                 return;
             }
 
             // Merge the data.
-            if ($data_merged === NULL) {
-                $data_merged = $data;
-            }
-            elseif ($data) {
-                $data_merged = array_merge_recursive($data, $data_merged);
+            if ($dataMerged === null) {
+                $dataMerged = $data;
+            } elseif ($data) {
+                $dataMerged = array_merge_recursive($data, $dataMerged);
             }
         }
 
         // Save the configuration file.
-        $this->writeTaskConfigFile($info['type'], $info['grumphp'], $data_merged);
+        $this->writeTaskConfigFile($info['type'], $info['grumphp'], $dataMerged);
     }
 
     /**
      * Remove the task configuration file.
      *
-     * @param TaskEvent $event The GrumPHP task event.
+     * @param \GrumPHP\Event\TaskEvent $event
+     *   The GrumPHP task event.
      */
-    public function removeTaskConfig(TaskEvent $event)
+    public function removeTaskConfig(TaskEvent $event): void
     {
-        if (!$info = $this->getTaskConfigFileInfo($event->getTask())) {
+        $info = $this->getTaskConfigFileInfo($event->getTask());
+        if (!$info) {
             return;
         }
 
-        $fs = new Filesystem();
+        $filesystem = new Filesystem();
 
-        if ($fs->exists($info['grumphp'])) {
-            $fs->remove($info['grumphp']);
+        if ($filesystem->exists($info['grumphp'])) {
+            $filesystem->remove($info['grumphp']);
         }
     }
 
     /**
      * Get some information about the task configuration file.
      *
-     * @param TaskInterface $task The GrumPHP task.
+     * @param \GrumPHP\Task\TaskInterface $task
+     *   The GrumPHP task.
      *
-     * @return array|null The task configuration info (filename, extension, type and name of the
-     *                    temporary merged file for GrumPHP) as associative array.
+     * @return array|null
+     *   The task configuration info (filename, extension, type and name of the
+     *   temporary merged file for GrumPHP) as associative array.
      */
-    protected function getTaskConfigFileInfo(TaskInterface $task)
+    private function getTaskConfigFileInfo(TaskInterface $task): ?array
     {
         $info = null;
 
@@ -124,28 +147,28 @@ class TaskEventListener
                 'type' => self::FILETYPE_YAML,
             ];
         }
-        elseif ($task instanceof Phpcs) {
+        if ($task instanceof Phpcs) {
             $info = [
                 'filename' => 'phpcs',
                 'extension' => 'xml',
                 'type' => self::FILETYPE_XML,
             ];
         }
-        elseif ($task instanceof PhpMd) {
+        if ($task instanceof PhpMd) {
             $info = [
                 'filename' => 'phpmd',
                 'extension' => 'xml',
                 'type' => self::FILETYPE_XML,
             ];
         }
-        elseif ($task instanceof PhpStan) {
+        if ($task instanceof PhpStan) {
             $info = [
                 'filename' => 'phpstan',
                 'extension' => 'neon',
                 'type' => self::FILETYPE_NEON,
             ];
         }
-        elseif ($task instanceof Phpunit) {
+        if ($task instanceof Phpunit) {
             $info = [
                 'filename' => 'phpunit',
                 'extension' => 'xml',
@@ -154,7 +177,11 @@ class TaskEventListener
         }
 
         if ($info) {
-            $info['grumphp'] = '.' . $info['filename'] . '.qa-drupal.' . $info['extension'];
+            $info['grumphp'] = sprintf(
+                '%s.qa-drupal.%s',
+                $info['filename'],
+                $info['extension']
+            );
         }
 
         return $info;
@@ -168,7 +195,7 @@ class TaskEventListener
      *
      * @return array|false The configuration data or false if not supported.
      */
-    protected function readTaskConfigFile($type, $file)
+    private function readTaskConfigFile($type, $file)
     {
         switch ($type) {
             case self::FILETYPE_YAML:
@@ -189,24 +216,24 @@ class TaskEventListener
      *
      * @param array|null $data The configuration data.
      */
-    protected function writeTaskConfigFile($type, $file, array $data)
+    private function writeTaskConfigFile($type, $file, array $data): void
     {
         switch ($type) {
             case self::FILETYPE_YAML:
-                $data = Yaml::dump($data);
+                $rawData = Yaml::dump($data);
                 break;
 
             case self::FILETYPE_NEON:
-                $data = Neon::encode($data, Neon::BLOCK);
+                $rawData = Neon::encode($data, Neon::BLOCK);
                 break;
 
             default:
-                $data = '';
+                $rawData = '';
                 break;
         }
 
-        $fs = new Filesystem();
-        $fs->dumpFile($file, $data);
+        $filesystem = new Filesystem();
+        $filesystem->dumpFile($file, $rawData);
     }
 
     /**
@@ -216,9 +243,9 @@ class TaskEventListener
      */
     protected function isExtension()
     {
-        if ($this->isExtension === NULL) {
-            $fs = new Filesystem();
-            $this->isExtension = !$fs->exists('web/index.php');
+        if ($this->isExtension === null) {
+            $filesystem = new Filesystem();
+            $this->isExtension = !$filesystem->exists('web/index.php');
         }
 
         return $this->isExtension;

--- a/src/PHPUnit/Extension/bootstrap.php
+++ b/src/PHPUnit/Extension/bootstrap.php
@@ -1,0 +1,240 @@
+<?php
+
+/**
+ * @file
+ * Bootstrap for PHPUnit tests run within a module project.
+ *
+ * This will automatically detect the tests and run them using the Drupal code
+ * within the vendor directory.
+ *
+ * Copied from drupal/core/tests/bootstrap.php.
+ */
+
+use Drupal\Component\Assertion\Handle;
+use Drupal\Core\Composer\Composer;
+use PHPUnit\Runner\Version;
+
+/**
+ * Get the root directory of the current project.
+ *
+ * @return string
+ *   The root directory.
+ */
+function drupal_phpunit_root_dir(): string
+{
+    return dirname(__FILE__, 7);
+}
+
+/**
+ * Finds all valid extension directories recursively within a given directory.
+ *
+ * @param string $scanDirectory
+ *   The directory that should be recursively scanned.
+ *
+ * @return array
+ *   An associative array of extension directories found within the scanned
+ *   directory, keyed by extension name.
+ */
+function drupal_phpunit_find_extension_directories($scanDirectory): array
+{
+    $extensions = [];
+    $dirs = new \RecursiveIteratorIterator(
+        new \RecursiveDirectoryIterator(
+            $scanDirectory,
+            \RecursiveDirectoryIterator::FOLLOW_SYMLINKS
+        )
+    );
+
+    foreach ($dirs as $dir) {
+        if (strpos($dir->getPathname(), '.info.yml') !== false) {
+            // Cut off ".info.yml" from the filename for use as the extension name. We
+            // use getRealPath() so that we can scan extensions represented by
+            // directory aliases.
+            $extensions[substr($dir->getFilename(), 0, -9)] = $dir
+                ->getPathInfo()
+                ->getRealPath();
+        }
+    }
+
+    return $extensions;
+}
+
+/**
+ * Returns directories under which contributed extensions may exist.
+ *
+ * @return array
+ *   An array of directories under which contributed extensions may exist.
+ */
+function drupal_phpunit_contrib_extension_directory_roots()
+{
+    return [
+        drupal_phpunit_root_dir() . '/',
+        drupal_phpunit_root_dir() . '/vendor/drupal/core/modules',
+    ];
+}
+
+/**
+ * Registers the namespace for each extension directory with the autoloader.
+ *
+ * @param array $dirs
+ *   An associative array of extension directories, keyed by extension name.
+ *
+ * @return array
+ *   An associative array of extension directories, keyed by their namespace.
+ */
+function drupal_phpunit_get_extension_namespaces(array $dirs)
+{
+    $suiteNames = ['Unit', 'Kernel', 'Functional', 'FunctionalJavascript'];
+    $namespaces = [];
+    foreach ($dirs as $extension => $dir) {
+        if (is_dir($dir . '/src')) {
+            // Register the PSR-4 directory for module-provided classes.
+            $namespaces['Drupal\\' . $extension . '\\'][] = $dir . '/src';
+        }
+
+        $testDir = $dir . '/tests/src';
+        if (!is_dir($testDir)) {
+            continue;
+        }
+
+        foreach ($suiteNames as $suiteName) {
+            $suiteDir = $testDir . '/' . $suiteName;
+            if (is_dir($suiteDir)) {
+                // Register the PSR-4 directory for PHPUnit-based suites.
+                $namespaces['Drupal\\Tests\\' . $extension . '\\' . $suiteName . '\\'][] = $suiteDir;
+            }
+        }
+
+        // Extensions can have a \Drupal\extension\Traits namespace for
+        // cross-suite trait code.
+        $traitDir = $testDir . '/Traits';
+        if (is_dir($traitDir)) {
+            $namespaces['Drupal\\Tests\\' . $extension . '\\Traits\\'][] = $traitDir;
+        }
+    }
+
+    return $namespaces;
+}
+
+/**
+ * Populate class loader with additional namespaces for tests.
+ *
+ * We run this in a function to avoid setting the class loader to a global
+ * that can change. This change can cause unpredictable false positives for
+ * phpunit's global state change watcher. The class loader can be retrieved from
+ * composer at any time by requiring autoload.php.
+ */
+function drupal_phpunit_populate_class_loader()
+{
+    /** @var \Composer\Autoload\ClassLoader $loader */
+    $loader = require drupal_phpunit_root_dir() . '/vendor/autoload.php';
+
+    $dir = drupal_phpunit_root_dir() . '/vendor/drupal/core/tests';
+
+    // Start with classes in known locations.
+    $loader->add('Drupal\\Tests', $dir);
+    $loader->add('Drupal\\KernelTests', $dir);
+    $loader->add('Drupal\\FunctionalTests', $dir);
+    $loader->add('Drupal\\FunctionalJavascriptTests', $dir);
+    $loader->add('Drupal\\BuildTests', $dir);
+    $loader->add('Drupal\\TestTools', $dir);
+
+    if (!isset($GLOBALS['namespaces'])) {
+        // Scan for arbitrary extension namespaces from core and contrib.
+        $extensionRoots = drupal_phpunit_contrib_extension_directory_roots();
+
+        $dirs = array_map(
+            'drupal_phpunit_find_extension_directories',
+            $extensionRoots
+        );
+        $dirs = array_reduce($dirs, 'array_merge', []);
+        $GLOBALS['namespaces'] = drupal_phpunit_get_extension_namespaces($dirs);
+    }
+    foreach ($GLOBALS['namespaces'] as $prefix => $paths) {
+        $loader->addPsr4($prefix, $paths);
+    }
+
+    return $loader;
+}
+
+// Do class loader population.
+drupal_phpunit_populate_class_loader();
+
+// Ensure we have the correct PHPUnit version for the version of PHP.
+if (class_exists('\PHPUnit_Runner_Version')) {
+    $phpunitVersion = \PHPUnit_Runner_Version::id();
+} else {
+    $phpunitVersion = Version::id();
+}
+if (!Composer::upgradePHPUnitCheck($phpunitVersion)) {
+    $message = "PHPUnit testing framework version 6 or greater is required when running on PHP 7.2 or greater. Run the command 'composer run-script drupal-phpunit-upgrade' in order to fix this.";
+    echo "\033[31m" . $message . "\n\033[0m";
+    exit(1);
+}
+
+// Set sane locale settings, to ensure consistent string, dates, times and
+// numbers handling.
+// @see \Drupal\Core\DrupalKernel::bootEnvironment()
+setlocale(LC_ALL, 'C');
+
+// Set the default timezone. While this doesn't cause any tests to fail, PHP
+// complains if 'date.timezone' is not set in php.ini. The Australia/Sydney
+// timezone is chosen so all tests are run using an edge case scenario (UTC+10
+// and DST). This choice is made to prevent timezone related regressions and
+// reduce the fragility of the testing system in general.
+date_default_timezone_set('Australia/Sydney');
+
+// Runtime assertions. PHPUnit follows the php.ini assert.active setting for
+// runtime assertions. By default this setting is on. Here we make a call to
+// make PHP 5 and 7 handle assertion failures the same way, but this call does
+// not turn runtime assertions on if they weren't on already.
+Handle::register();
+
+// PHPUnit 4 to PHPUnit 6 bridge. Tests written for PHPUnit 4 need to work on
+// PHPUnit 6 with a minimum of fuss.
+if (version_compare($phpunitVersion, '6.1', '>=')) {
+    class_alias(
+        '\PHPUnit\Framework\AssertionFailedError',
+        '\PHPUnit_Framework_AssertionFailedError'
+    );
+    class_alias(
+        '\PHPUnit\Framework\Constraint\Count',
+        '\PHPUnit_Framework_Constraint_Count'
+    );
+    class_alias(
+        '\PHPUnit\Framework\Error\Error',
+        '\PHPUnit_Framework_Error'
+    );
+    class_alias(
+        '\PHPUnit\Framework\Error\Warning',
+        '\PHPUnit_Framework_Error_Warning'
+    );
+    class_alias(
+        '\PHPUnit\Framework\ExpectationFailedException',
+        '\PHPUnit_Framework_ExpectationFailedException'
+    );
+    class_alias(
+        '\PHPUnit\Framework\Exception',
+        '\PHPUnit_Framework_Exception'
+    );
+    class_alias(
+        '\PHPUnit\Framework\MockObject\Matcher\InvokedRecorder',
+        '\PHPUnit_Framework_MockObject_Matcher_InvokedRecorder'
+    );
+    class_alias(
+        '\PHPUnit\Framework\SkippedTestError',
+        '\PHPUnit_Framework_SkippedTestError'
+    );
+    class_alias(
+        '\PHPUnit\Framework\TestCase',
+        '\PHPUnit_Framework_TestCase'
+    );
+    class_alias(
+        '\PHPUnit\Util\Test',
+        '\PHPUnit_Util_Test'
+    );
+    class_alias(
+        '\PHPUnit\Util\XML',
+        '\PHPUnit_Util_XML'
+    );
+}

--- a/src/PHPUnit/TestSuites/FunctionalJavascriptTestSuite.php
+++ b/src/PHPUnit/TestSuites/FunctionalJavascriptTestSuite.php
@@ -12,7 +12,7 @@ class FunctionalJavascriptTestSuite extends TestSuiteBase
      *
      * @return static The test suite.
      */
-    public static function suite()
+    public static function suite(): FunctionalJavascriptTestSuite
     {
         return new static('functional-javascript', 'FunctionalJavascript');
     }

--- a/src/PHPUnit/TestSuites/FunctionalTestSuite.php
+++ b/src/PHPUnit/TestSuites/FunctionalTestSuite.php
@@ -12,7 +12,7 @@ class FunctionalTestSuite extends TestSuiteBase
      *
      * @return static The test suite.
      */
-    public static function suite()
+    public static function suite(): FunctionalTestSuite
     {
         return new static('functional', 'Functional');
     }

--- a/src/PHPUnit/TestSuites/KernelTestSuite.php
+++ b/src/PHPUnit/TestSuites/KernelTestSuite.php
@@ -12,7 +12,7 @@ class KernelTestSuite extends TestSuiteBase
      *
      * @return static The test suite.
      */
-    public static function suite()
+    public static function suite(): KernelTestSuite
     {
         return new static('kernel', 'Kernel');
     }

--- a/src/PHPUnit/TestSuites/UnitTestSuite.php
+++ b/src/PHPUnit/TestSuites/UnitTestSuite.php
@@ -12,7 +12,7 @@ class UnitTestSuite extends TestSuiteBase
      *
      * @return static The test suite.
      */
-    public static function suite()
+    public static function suite(): UnitTestSuite
     {
         return new static('unit', 'Unit');
     }


### PR DESCRIPTION
- Fixed PHP CodeSniffer rules so they follow drupal.org.
- Fixed PHP Mess Detector rules so they have proper defaults and support drupal codebase.
- Fixed timeout issues when running GrumPHP tasks on large code base.
- Added support to run PHPUnit tests without the need of an external Drupal directory.