### PR TITLE
Add Drupal 9 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "require": {
         "php": "^7.3",
         "drupal/coder": "^8.3",
-        "drupal/core": "^8.9",
+        "drupal/core": "^8.8 || ^9.0",
         "drupal/drupal-extension": "^4.1",
         "ergebnis/composer-normalize": "^2.8",
         "irstea/phpcpd-shim": "^6.0",

--- a/configs/phpmd.xml
+++ b/configs/phpmd.xml
@@ -26,17 +26,28 @@
   </rule>
 
   <rule ref="rulesets/codesize.xml" />
-  <!--rule ref="rulesets/codesize.xml/ExcessiveMethodLength">
-    <properties>
-      <property name="minimum" value="250" />
-    </properties>
-  </rule-->
 
   <rule ref="rulesets/design.xml" />
 
-  <rule ref="rulesets/naming.xml" />
-  <rule ref="rulesets/naming.xml/ShortVariable">
+  <rule ref="rulesets/naming.xml">
+    <exclude name="ShortMethodName" />
+    <exclude name="ShortVariable" />
+  </rule>
+  <rule ref="rulesets/naming.xml/ShortMethodName">
+    <!--
+      Allow "id()" as a short method name.
+    -->
     <properties>
+      <property name="minimum" value="2" />
+      <property name="exceptions" value="id" />
+    </properties>
+  </rule>
+  <rule ref="rulesets/naming.xml/ShortVariable">
+    <!--
+      Allow "$id" as a short variable name.
+    -->
+    <properties>
+      <property name="minimum" value="2" />
       <property name="exceptions" value="id" />
     </properties>
   </rule>


### PR DESCRIPTION
- Add Drupal 9.0 support.
- Allow short `$id` variable and `id()` method name.