### PR TITLE
Add support for Drupal 9.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,8 +37,8 @@
         "phpro/grumphp-shim": "^1.1",
         "phpspec/prophecy": "^1.10",
         "phpstan/phpstan-deprecation-rules": "^0.12.5",
-        "phpunit/phpunit": "^7.5",
-        "symfony/phpunit-bridge": "^3.4.3"
+        "phpunit/phpunit": "^7.5 || ^8.4 || ^9",
+        "symfony/phpunit-bridge": "^3.4 || ^5.2"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
Drupal 9.1 requires PHPUnit 9.

See https://github.com/drupal/core-dev/blob/9.1.x/composer.json
See https://www.drupal.org/node/3176567