### PR TITLE
Fix PHPStan & PHPUnit integration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# Drupal editor configuration normalization
+# @see http://editorconfig.org/
+
+# This is the top-most .editorconfig file; do not search in parent directories.
+root = true
+
+# All files.
+[*]
+end_of_line = LF
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All Notable changes to the **Quality Assurance - Drupal** package.
 ### Fixed
 
 - Fix the PHPUnit/Symfony deprecation warning (Drupal 8).
+- Fix incompatible UnitTest::setUp() method (Drupal 9).
 
 ## [1.4.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All Notable changes to the **Quality Assurance - Drupal** package.
 
 - Add setting up a fake Drupal root for tasks who requires it.
 
+### Fixed
+
+- Fix the PHPUnit/Symfony deprecation warning (Drupal 8).
+
 ## [1.4.3]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All Notable changes to the **Quality Assurance - Drupal** package.
 ### Added
 
 - Add setting up a fake Drupal root for tasks who requires it.
+- Add composer_normalize to the GrumPHP tasks.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All Notable changes to the **Quality Assurance - Drupal** package.
 
+## [Unreleases]
+
+### Added
+
+- Add setting up a fake Drupal root for tasks who requires it.
+
 ## [1.4.3]
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "drupal/coder": "^8.3",
         "drupal/core": "^8.8 || ^9.0",
         "drupal/drupal-extension": "^4.1",
-        "ergebnis/composer-normalize": "^2.8",
+        "ergebnis/composer-normalize": "^2.11",
         "irstea/phpcpd-shim": "^6.0",
         "irstea/phpmd-shim": "^2.9",
         "mglaman/phpstan-drupal": "^0.12.6",

--- a/composer.json
+++ b/composer.json
@@ -5,17 +5,17 @@
     "authors": [
         {
             "name": "Matthijs Van Assche",
-            "email": "matthijs.vanassche@digipolis.gent",
+            "email": "matthijs.vanassche@district09.gent",
             "role": "developer"
         },
         {
             "name": "Maarten Segers",
-            "email": "maarten.segers@digipolis.gent",
+            "email": "maarten.segers@district09.gent",
             "role": "developer"
         },
         {
             "name": "Peter Decuyper",
-            "email": "peter.decuyper@digipolis.gent",
+            "email": "peter.decuyper@district09.gent",
             "role": "developer"
         }
     ],

--- a/configs/grumphp-extension.yml
+++ b/configs/grumphp-extension.yml
@@ -30,6 +30,7 @@ grumphp:
         - phpunit
   tasks:
     composer: ~
+    composer_normalize: ~
     git_blacklist:
       keywords:
         - " die\\("

--- a/configs/grumphp-extension.yml
+++ b/configs/grumphp-extension.yml
@@ -126,7 +126,12 @@ grumphp:
         - "#^vendor/#"
 
 services:
+  listener.qa_drupal.console:
+    class: Digipolisgent\QA\Drupal\GrumPHP\EventListener\ConsoleEventListener
+    tags:
+      - { name: grumphp.event_listener, event: console.terminate, method: onTerminate }
+      - { name: grumphp.event_listener, event: console.exception, method: onException }
   listener.qa_drupal.task:
     class: Digipolisgent\QA\Drupal\GrumPHP\EventListener\TaskEventListener
     tags:
-      - { name: grumphp.event_listener, event: grumphp.task.run, method: createTaskConfig, priority: 100 }
+      - { name: grumphp.event_listener, event: grumphp.task.run, method: onRun, priority: 100 }

--- a/configs/grumphp-site.yml
+++ b/configs/grumphp-site.yml
@@ -34,6 +34,7 @@ grumphp:
       config: behat.qa-drupal.yml
     composer:
       no_check_publish: true
+    composer_normalize: ~
     git_blacklist:
       keywords:
         - " die\\("

--- a/configs/phpstan-extension.neon
+++ b/configs/phpstan-extension.neon
@@ -1,3 +1,5 @@
 parameters:
+  scanDirectories:
+    - %currentWorkingDirectory%
   drupal:
-    drupal_root: ../drupal
+    drupal_root: vendor/drupal

--- a/configs/phpunit-extension.xml
+++ b/configs/phpunit-extension.xml
@@ -8,8 +8,10 @@
          beStrictAboutChangesToGlobalState="true">
 
   <php>
-    <ini name="error_reporting" value="32767"/>
-    <ini name="memory_limit" value="-1"/>
+    <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak" />
+
+    <ini name="error_reporting" value="32767" />
+    <ini name="memory_limit" value="-1" />
   </php>
 
   <testsuites>

--- a/configs/phpunit-site.xml
+++ b/configs/phpunit-site.xml
@@ -8,8 +8,8 @@
          beStrictAboutChangesToGlobalState="true">
 
   <php>
-    <ini name="error_reporting" value="32767"/>
-    <ini name="memory_limit" value="-1"/>
+    <ini name="error_reporting" value="32767" />
+    <ini name="memory_limit" value="-1" />
   </php>
 
   <testsuites>

--- a/src/GrumPHP/ConfigFileMerger.php
+++ b/src/GrumPHP/ConfigFileMerger.php
@@ -11,6 +11,7 @@ use GrumPHP\Task\PhpStan;
 use GrumPHP\Task\Phpunit;
 use GrumPHP\Task\TaskInterface;
 use Nette\Neon\Neon;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -19,6 +20,9 @@ use Symfony\Component\Yaml\Yaml;
  * This will create a config file on-the-fly based on:
  * - The example config files in qa-drupal.
  * - Combined or replaced by the config file in the root of the project.
+ *
+ * NOTE: Config files are stored permanantly as they can be required by IDE
+ *       tools.
  */
 final class ConfigFileMerger
 {
@@ -66,7 +70,7 @@ final class ConfigFileMerger
     /**
      * The symfony filesystem.
      *
-     * @var \Digipolisgent\QA\Drupal\GrumPHP\TransactionalFilesystem
+     * @var \Symfony\Component\Filesystem\Filesystem
      */
     private $filesystem;
 
@@ -75,7 +79,7 @@ final class ConfigFileMerger
      */
     public function __construct()
     {
-        $this->filesystem = TransactionalFilesystem::getInstance();
+        $this->filesystem = new Filesystem();
     }
 
     /**
@@ -117,11 +121,9 @@ final class ConfigFileMerger
             }
 
             // Merge the configuration.
-            if ($config === null) {
-                $config = $loaded;
-            } elseif ($loaded) {
-                $config = array_replace_recursive($loaded, $config);
-            }
+            $config = $config === null
+                ? $loaded
+                : array_replace_recursive($loaded, $config);
         }
 
         // Save the merged configuration.
@@ -229,6 +231,6 @@ final class ConfigFileMerger
                 break;
         }
 
-        $this->filesystem->writeFile($file, $config);
+        $this->filesystem->dumpFile($file, $config);
     }
 }

--- a/src/GrumPHP/ConfigFileMerger.php
+++ b/src/GrumPHP/ConfigFileMerger.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Digipolisgent\QA\Drupal\GrumPHP;
+
+use GrumPHP\Task\Behat;
+use GrumPHP\Task\Phpcs;
+use GrumPHP\Task\PhpMd;
+use GrumPHP\Task\PhpStan;
+use GrumPHP\Task\Phpunit;
+use GrumPHP\Task\TaskInterface;
+use Nette\Neon\Neon;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Create a config file, as required by the task, on-the-fly.
+ *
+ * This will create a config file on-the-fly based on:
+ * - The example config files in qa-drupal.
+ * - Combined or replaced by the config file in the root of the project.
+ */
+final class ConfigFileMerger
+{
+
+    /**
+     * Configuration file types.
+     */
+    private const FILETYPE_XML = 'xml';
+    private const FILETYPE_YAML = 'yaml';
+    private const FILETYPE_NEON = 'neon';
+
+    /**
+     * Mapping of task types and their configuration files.
+     *
+     * @var array
+     */
+    private $taskInfo = [
+        Behat::class => [
+            'filename' => 'behat',
+            'extension' => 'yml',
+            'type' => self::FILETYPE_YAML,
+        ],
+        Phpcs::class => [
+            'filename' => 'phpcs',
+            'extension' => 'xml',
+            'type' => self::FILETYPE_XML,
+        ],
+        PhpMd::class => [
+            'filename' => 'phpmd',
+            'extension' => 'xml',
+            'type' => self::FILETYPE_XML,
+        ],
+        PhpStan::class => [
+            'filename' => 'phpstan',
+            'extension' => 'neon',
+            'type' => self::FILETYPE_NEON,
+        ],
+        Phpunit::class => [
+            'filename' => 'phpunit',
+            'extension' => 'xml',
+            'type' => self::FILETYPE_XML,
+        ],
+    ];
+
+    /**
+     * The symfony filesystem.
+     *
+     * @var \Digipolisgent\QA\Drupal\GrumPHP\TransactionalFilesystem
+     */
+    private $filesystem;
+
+    /**
+     * Class constructor.
+     */
+    public function __construct()
+    {
+        $this->filesystem = TransactionalFilesystem::getInstance();
+    }
+
+    /**
+     * Create the task configuration file.
+     *
+     * @param \GrumPHP\Task\TaskInterface $task
+     *   The GrumPHP task.
+     * @param bool $isExtension
+     *   The files need to be merged for an extension.
+     */
+    public function mergeTaskConfig(
+        TaskInterface $task,
+        bool $isExtension
+    ): void {
+        $taskInfo = $this->getTaskConfigFileInfo($task);
+        if (!$taskInfo) {
+            return;
+        }
+
+        // Candidate configuration files.
+        $candidates = $this->getConfigFileCandidates($taskInfo, $isExtension);
+
+        // Search for the candidates and merge or copy them.
+        $config = null;
+
+        foreach ($candidates as $env_var => $file) {
+            // Ignore if configured to skip or if the file is missing.
+            if (!empty($_SERVER[$env_var]) || !$this->filesystem->exists($file)) {
+                continue;
+            }
+
+            // Load the configuration file.
+            $loaded = $this->loadTaskConfigFile($taskInfo['type'], $file);
+
+            // Just copy the file if it isn't readable.
+            if ($loaded === false) {
+                $this->filesystem->copy($file, $taskInfo['grumphp']);
+                return;
+            }
+
+            // Merge the configuration.
+            if ($config === null) {
+                $config = $loaded;
+            } elseif ($loaded) {
+                $config = array_replace_recursive($loaded, $config);
+            }
+        }
+
+        // Save the merged configuration.
+        if ($config !== null) {
+            $this->saveTaskConfigFile($taskInfo, $config);
+        }
+    }
+
+    /**
+     * Get some information about the task configuration file.
+     *
+     * @param \GrumPHP\Task\TaskInterface $task
+     *   The GrumPHP task.
+     *
+     * @return array|null
+     *   The task configuration info (filename, extension, type and name of the
+     *   temporary merged file for GrumPHP) as associative array.
+     */
+    private function getTaskConfigFileInfo(TaskInterface $task)
+    {
+        $taskClass = get_class($task);
+        if (empty($this->taskInfo[$taskClass])) {
+            return null;
+        }
+
+        $info = $this->taskInfo[$taskClass];
+        $info['grumphp'] = sprintf(
+            '%s.qa-drupal.%s',
+            $info['filename'],
+            $info['extension']
+        );
+
+        return $info;
+    }
+
+    /**
+     * Get the candidate configuration files to merge from.
+     *
+     * @param array $taskInfo
+     *   The task information to get the candidates for.
+     * @param bool $isExtension
+     *   Is the task run in an extension project.
+     */
+    private function getConfigFileCandidates(
+        array $taskInfo,
+        bool $isExtension
+    ): array {
+        // Candidate configuration files.
+        $key = strtoupper($taskInfo['filename']) . '_SKIP_';
+        $type = ($isExtension ? 'extension' : 'site');
+        $path = dirname(__FILE__, 3) . '/configs/';
+
+        return [
+            $key . 'LOCAL' => $taskInfo['filename'] . '.local.' . $taskInfo['extension'],
+            $key . 'PROJECT' => $taskInfo['filename'] . '.' . $taskInfo['extension'],
+            $key . 'PACKAGE_TYPE' => $path . $taskInfo['filename'] . '-' . $type . '.' . $taskInfo['extension'],
+            $key . 'PACKAGE_GLOBAL' => $path . $taskInfo['filename'] . '.' . $taskInfo['extension'],
+        ];
+    }
+
+    /**
+     * Read and parse a task configuration file.
+     *
+     * @param string $type
+     *   The file type.
+     * @param string $file
+     *   Path to the file.
+     *
+     * @return array|false
+     *   The configuration data or false if not supported.
+     */
+    private function loadTaskConfigFile($type, $file)
+    {
+        switch ($type) {
+            case self::FILETYPE_YAML:
+                return Yaml::parseFile($file);
+
+            case self::FILETYPE_NEON:
+                return Neon::decode(file_get_contents($file));
+        }
+
+        return false;
+    }
+
+    /**
+     * Write a config file.
+     *
+     * @param array $taskInfo
+     *   The task info.
+     * @param array|null $data
+     *   The configuration data.
+     */
+    private function saveTaskConfigFile($taskInfo, ?array $config)
+    {
+        $type = $taskInfo['type'];
+        $file = $taskInfo['grumphp'];
+
+        switch ($type) {
+            case self::FILETYPE_YAML:
+                $config = Yaml::dump($config);
+                break;
+
+            case self::FILETYPE_NEON:
+                $config = Neon::encode($config, Neon::BLOCK);
+                break;
+        }
+
+        $this->filesystem->writeFile($file, $config);
+    }
+}

--- a/src/GrumPHP/EventListener/ConsoleEventListener.php
+++ b/src/GrumPHP/EventListener/ConsoleEventListener.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Digipolisgent\QA\Drupal\GrumPHP\EventListener;
+
+use Digipolisgent\QA\Drupal\GrumPHP\TransactionalFilesystem;
+
+/**
+ * Listener for Symfony console events.
+ */
+final class ConsoleEventListener
+{
+
+    /**
+     * Invoked when the console command terminates.
+     *
+     * This will:
+     * - Rollback any filesystem changes.
+     */
+    public function onTerminate(): void
+    {
+        TransactionalFilesystem::getInstance()->rollback();
+    }
+
+    /**
+     * Invoked when the console command throws an unhandled exception.
+     *
+     * This will:
+     * - Rollback any filesystem changes.
+     */
+    public function onException(): void
+    {
+        TransactionalFilesystem::getInstance()->rollback();
+    }
+}

--- a/src/GrumPHP/EventListener/TaskEventListener.php
+++ b/src/GrumPHP/EventListener/TaskEventListener.php
@@ -1,229 +1,122 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Digipolisgent\QA\Drupal\GrumPHP\EventListener;
 
+use Digipolisgent\QA\Drupal\GrumPHP\ConfigFileMerger;
+use Digipolisgent\QA\Drupal\GrumPHP\TransactionalFilesystem;
 use GrumPHP\Event\TaskEvent;
-use GrumPHP\Task\Behat;
-use GrumPHP\Task\Phpcs;
-use GrumPHP\Task\PhpMd;
-use GrumPHP\Task\PhpStan;
-use GrumPHP\Task\Phpunit;
 use GrumPHP\Task\TaskInterface;
-use Nette\Neon\Neon;
-use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\Yaml\Yaml;
 
 /**
  * Listener for GrumPHP task events.
+ *
+ * This will create a config file on-the-fly based on:
+ * - the example config files in qa-drupal.
+ * - combined or replaced by the config file in the root of the project.
+ *
+ * This will prepare a "Drupal installation" so PHPStan & PHPUnit can run from
+ * the Drupal directory within the vendor/drupal directory.
  */
 final class TaskEventListener
 {
-    /**
-     * Configuration file types.
-     */
-    private const FILETYPE_XML = 'xml';
-    private const FILETYPE_YAML = 'yaml';
-    private const FILETYPE_NEON = 'neon';
 
     /**
      * Indicates whether the project is an extension.
      *
      * @var bool
      */
-    private $isExtension;
+    protected $isExtension;
 
     /**
-     * Mapping of task types and their configuration files.
+     * Invoked when a task is run.
      *
-     * @var array
+     * @param \GrumPHP\Event\TaskEvent $event
+     *   The GrumPHP task event.
      */
-    private $taskInfo = [
-        Behat::class => [
-            'filename' => 'behat',
-            'extension' => 'yml',
-            'type' => self::FILETYPE_YAML,
-        ],
-        Phpcs::class => [
-            'filename' => 'phpcs',
-            'extension' => 'xml',
-            'type' => self::FILETYPE_XML,
-        ],
-        PhpMd::class => [
-            'filename' => 'phpmd',
-            'extension' => 'xml',
-            'type' => self::FILETYPE_XML,
-        ],
-        PhpStan::class => [
-            'filename' => 'phpstan',
-            'extension' => 'neon',
-            'type' => self::FILETYPE_NEON,
-        ],
-        Phpunit::class => [
-            'filename' => 'phpunit',
-            'extension' => 'xml',
-            'type' => self::FILETYPE_XML,
-        ],
-    ];
+    public function onRun(TaskEvent $event)
+    {
+        $task = $event->getTask();
+
+        $this->prepareConfigFile($task);
+        $this->prepareExtension($task);
+    }
 
     /**
      * Create the task configuration file.
      *
-     * @param TaskEvent $event The GrumPHP task event.
+     * @param \GrumPHP\Task\TaskInterface $task
+     *   The GrumPHP task.
      */
-    public function createTaskConfig(TaskEvent $event): void
+    private function prepareConfigFile(TaskInterface $task)
     {
-        $info = $this->getTaskConfigFileInfo($event->getTask());
-        if (!$info) {
-            return;
-        }
-
-        // Candidate configuration files.
-        $keyPrefix = strtoupper($info['filename']) . '_SKIP_';
-        $typeSuffix = ($this->isExtension() ? 'extension' : 'site');
-        $packagePath = __DIR__ . '/../../../configs/';
-
-        $candidates = [
-            $keyPrefix . 'LOCAL' => sprintf(
-                '%s.local.%s',
-                $info['filename'],
-                $info['extension']
-            ),
-            $keyPrefix . 'PROJECT' => sprintf(
-                '%s.%s',
-                $info['filename'],
-                $info['extension']
-            ),
-            $keyPrefix . 'PACKAGE_TYPE' => sprintf(
-                '%s%s-%s.%s',
-                $packagePath,
-                $info['filename'],
-                $typeSuffix,
-                $info['extension']
-            ),
-            $keyPrefix . 'PACKAGE_GLOBAL' => sprintf(
-                '%s%s.%s',
-                $packagePath,
-                $info['filename'],
-                $info['extension']
-            ),
-        ];
-
-        // Search for the candidates and merge or copy them.
-        $filesystem = new Filesystem();
-        $dataMerged = null;
-
-        foreach ($candidates as $env_var => $file) {
-            // Ignore if configured to skip or if the file is missing.
-            if (!empty($_SERVER[$env_var]) || !$filesystem->exists($file)) {
-                continue;
-            }
-
-            // Read and parse the configuration file.
-            $data = $this->readTaskConfigFile($info['type'], $file);
-
-            if ($data === false) {
-                // Just copy it if not readable.
-                $filesystem->copy($file, $info['grumphp']);
-                return;
-            }
-
-            // Merge the data.
-            if ($dataMerged === null) {
-                $dataMerged = $data;
-            } elseif ($data) {
-                $dataMerged = array_merge_recursive($data, $dataMerged);
-            }
-        }
-
-        // Save the configuration file.
-        $this->writeTaskConfigFile($info['type'], $info['grumphp'], $dataMerged);
+        $configMerger = new ConfigFileMerger();
+        $configMerger->mergeTaskConfig($task, $this->isExtension());
+        return;
     }
 
     /**
-     * Get some information about the task configuration file.
+     * Prepare environment for an extension.
+     *
+     * Nothing will be setup when the task is not run within an extension.
      *
      * @param \GrumPHP\Task\TaskInterface $task
      *   The GrumPHP task.
-     *
-     * @return array|null
-     *   The task configuration info (filename, extension, type and name of the
-     *   temporary merged file for GrumPHP) as associative array.
      */
-    private function getTaskConfigFileInfo(TaskInterface $task): ?array
+    private function prepareExtension(TaskInterface $task): void
     {
-        $taskClass = get_class($task);
-        if (empty($this->taskInfo[$taskClass])) {
-            return null;
+        if (!$this->isExtension()) {
+            return;
         }
 
-        $info = $this->taskInfo[$taskClass];
-        $info['grumphp'] = sprintf(
-            '%s.qa-drupal.%s',
-            $info['filename'],
-            $info['extension']
+        if ($task instanceof PhpStan) {
+            $this->prepareDrupalRoot();
+            $this->prepareDrupalSitesDirectory();
+        } elseif ($task instanceof Phpunit) {
+            $this->prepareDrupalSitesDirectory();
+        }
+    }
+
+    /**
+     * Create some files to mimic a Drupal root (for PHPStan).
+     */
+    private function prepareDrupalRoot()
+    {
+        $filesystem = TransactionalFilesystem::getInstance();
+        $filesystem->writeFile(
+            'vendor/drupal/vendor/autoload.php',
+            '<?php return include dirname(__FILE__, 3) . "/autoload.php";'
         );
-
-        return $info;
+        $filesystem->writeFile(
+            'vendor/drupal/autoload.php',
+            '<?php return include dirname(__FILE__, 2) . "/autoload.php";'
+        );
+        $filesystem->writeFile('vendor/drupal/composer.json', '{}');
     }
 
     /**
-     * Read and parse a task configuration file.
-     *
-     * @param string $type The file type.
-     * @param string $file Path to the file.
-     *
-     * @return array|false The configuration data or false if not supported.
+     * Create directories to mimic the Drupal sites directory.
      */
-    private function readTaskConfigFile($type, $file)
+    private function prepareDrupalSitesDirectory()
     {
-        switch ($type) {
-            case self::FILETYPE_YAML:
-                return Yaml::parseFile($file);
+        $filesystem = TransactionalFilesystem::getInstance();
 
-            case self::FILETYPE_NEON:
-                return Neon::decode(file_get_contents($file));
+        if (!$filesystem->exists('vendor/drupal/sites')) {
+            $filesystem->mkdir('vendor/drupal/sites');
         }
-
-        return false;
-    }
-
-    /**
-     * Write a config file.
-     *
-     * @param string $type The file type.
-     * @param string $file Path to the file.
-     *
-     * @param array|null $data The configuration data.
-     */
-    private function writeTaskConfigFile($type, $file, array $data): void
-    {
-        switch ($type) {
-            case self::FILETYPE_YAML:
-                $rawData = Yaml::dump($data);
-                break;
-
-            case self::FILETYPE_NEON:
-                $rawData = Neon::encode($data, Neon::BLOCK);
-                break;
-
-            default:
-                $rawData = '';
-                break;
-        }
-
-        $filesystem = new Filesystem();
-        $filesystem->dumpFile($file, $rawData);
     }
 
     /**
      * Checks wether the project is an extension.
      *
-     * @return bool True if the project is an extension.
+     * @return bool
+     *   True if the project is an extension.
      */
-    protected function isExtension()
+    private function isExtension(): bool
     {
         if ($this->isExtension === null) {
-            $filesystem = new Filesystem();
+            $filesystem = TransactionalFilesystem::getInstance();
             $this->isExtension = !$filesystem->exists('web/index.php');
         }
 

--- a/src/GrumPHP/TransactionalFilesystem.php
+++ b/src/GrumPHP/TransactionalFilesystem.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Digipolisgent\QA\Drupal\GrumPHP;
+
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * A basic transactional filesystem.
+ */
+final class TransactionalFilesystem {
+
+    /**
+     * The filsystem instance.
+     *
+     * @var \Digipolisgent\QA\Drupal\GrumPHP\TransactionalFilesystem
+     */
+    private static $instance;
+
+    /**
+     * The symfony filesystem.
+     *
+     * @var \Symfony\Component\Filesystem\Filesystem
+     */
+    private $filesystem;
+
+    /**
+     * A list of created directories.
+     *
+     * @var string[]
+     */
+    private $createdDirectories = [];
+
+    /**
+     * A list of created or chanced files.
+     *
+     * @var string[]
+     */
+    private $writtenFiles = [];
+
+    /**
+     * A list of backup files keyed by their original path.
+     *
+     * @var string[]
+     */
+    private $backupFiles = [];
+
+    /**
+     * Class constructor.
+     */
+    private function __construct() {
+        $this->filesystem = new Filesystem();
+    }
+
+    /**
+     * Get the filesystem instance.
+     *
+     * @return static
+     */
+    public static function getInstance(): TransactionalFilesystem {
+        if (!isset(self::$instance)) {
+            self::$instance = new static();
+        }
+
+        return self::$instance;
+    }
+
+    /**
+     * Check if a path exists.
+     *
+     * @param string $path
+     *   The path to check.
+     *
+     * @return bool
+     *   True if the path exists.
+     */
+    public function exists($path): bool {
+        return $this->filesystem->exists($path);
+    }
+
+    /**
+     * Create a directory.
+     *
+     * @param string $dir
+     *   The directory to create.
+     */
+    public function mkdir($dir): void {
+        // Leave if the directory already exists.
+        if (is_dir($dir)) {
+            return;
+        }
+
+        // Find the top most directory that will be created.
+        $created_dir = $dir;
+
+        do {
+            $tmp = dirname($created_dir);
+
+            if (is_dir($tmp)) {
+                break;
+            }
+
+            $created_dir = $tmp;
+        } while (TRUE);
+
+        // Create it and append it to the list.
+        $this->filesystem->mkdir($dir);
+        $this->createdDirectories[] = $created_dir;
+    }
+
+    /**
+     * Write to a file.
+     *
+     * @param string $file
+     *   The file to write to.
+     * @param string $content
+     *   The file content.
+     */
+    public function writeFile($file, $content): void {
+        // Backup the existing file.
+        if (is_file($file)) {
+            $this->backupFile($file);
+        }
+
+        // Dump the file.
+        $this->filesystem->dumpFile($file, $content);
+
+        // Add it to the list of written files.
+        $file = (string) $this->filesystem->readlink($file, TRUE);
+        $this->writtenFiles[] = $file;
+    }
+
+    /**
+     * Copy a file.
+     *
+     * @param string $file_from
+     *   The source file.
+     * @param string $file_to
+     *   The destination file.
+     */
+    public function copy(string $file_from, string $file_to): void {
+        // Backup the existing file.
+        if (is_file($file_to)) {
+            $this->backupFile($file_to);
+        }
+
+        // Copy the file.
+        $this->filesystem->copy($file_from, $file_to, TRUE);
+
+        // Add it to the list of written files.
+        $file_to = (string) $this->filesystem->readlink($file_to, TRUE);
+        $this->writtenFiles[] = $file_to;
+    }
+
+    /**
+     * Create a file backup.
+     *
+     * @param string $file
+     *   The file to backup.
+     */
+    protected function backupFile(string $file): void {
+        $file = (string) $this->filesystem->readlink($file, TRUE);
+
+        // Leave if the file was created or changed earlier.
+        if (in_array($file, $this->writtenFiles, TRUE)) {
+            return;
+        }
+
+        // Backup the file.
+        $backup = $file . '.qa-drupal';
+        $this->filesystem->copy($file, $backup, TRUE);
+        $this->backupFiles[$file] = $backup;
+    }
+
+    /**
+     * Commit the changes.
+     */
+    public function commit(): void {
+        foreach ($this->backupFiles as $backup) {
+            if ($this->filesystem->exists($backup)) {
+                $this->filesystem->remove($backup);
+            }
+        }
+
+        $this->createdDirectories = [];
+        $this->writtenFiles = [];
+        $this->backupFiles = [];
+    }
+
+    /**
+     * Rollback the changes.
+     */
+    public function rollback(): void {
+        // Remove the created directories.
+        foreach ($this->createdDirectories as $index => $dir) {
+            if ($this->filesystem->exists($dir)) {
+                $this->filesystem->remove($dir);
+            }
+
+            unset($this->createdDirectories[$index]);
+        }
+
+        // Remove the written files.
+        foreach ($this->writtenFiles as $index => $file) {
+            if ($this->filesystem->exists($file)) {
+                $this->filesystem->remove($file);
+            }
+
+            unset($this->writtenFiles[$index]);
+        }
+
+        // Restore the backup files.
+        foreach ($this->backupFiles as $file => $backup) {
+            if ($this->filesystem->exists($backup)) {
+                $this->filesystem->copy($backup, $file, TRUE);
+                $this->filesystem->remove($backup);
+            }
+
+            unset($this->backupFiles[$file]);
+        }
+    }
+
+    /**
+     * Commit the changes when the object is destroyed.
+     */
+    public function __destruct() {
+        $this->commit();
+    }
+}


### PR DESCRIPTION
## Add setting up a fake Drupal root for tasks who requires it

The PHPStan Drupal plugin to detect deprecations requires a Drupal root.
The implemented pre task event handler adds the missing files so PHPStan "sees" a Drupal installation.

Added the TransactionalFileSystem that automatically cleans up all directories and files created during a task run (merged from 1.3.x).

Extracted the config file merging functionality to a dedicated class.

## Fix the PHPUnit/Symfony deprecation warning (Drupal 8)

Deprecations are already detected by PHPStan, no need to detect these also during PHPUnit runs.

## Add composer_normalize to the GrumPHP tasks

This task is a wrapper around a composer plugin for tidying up the file composer.json.

## Fix incompatible UnitTest::setUp() method (Drupal 9)

Added using the use the `Drupal\TestTools\PhpUnitCompatibility\PhpUnit8\ClassWriter` to check and
fix incompatible `setUp()` methods in Drupal Core.
See https://www.drupal.org/node/3114041.
