### PR TITLE
Fix allowed number of deprecation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All Notable changes to the **Quality Assurance - Drupal** package.
 
+## [1.4.6]
+
+### Fixed
+
+- Fix allowed number of deprecation errors.
+
 ## [1.4.5]
 
 ### Fixed
@@ -185,6 +191,7 @@ Initial setup of the qa-drupal package:
 - Default config files and checks for a Drupal site.
 - Default config files and checks for a Drupal module.
 
+[1.4.6]: https://github.com/digipolisgent/php_package_qa-drupal/compare/1.4.5...1.4.6
 [1.4.5]: https://github.com/digipolisgent/php_package_qa-drupal/compare/1.4.4...1.4.5
 [1.4.4]: https://github.com/digipolisgent/php_package_qa-drupal/compare/1.4.3...1.4.4
 [1.4.3]: https://github.com/digipolisgent/php_package_qa-drupal/compare/1.4.2...1.4.3

--- a/configs/phpunit-extension.xml
+++ b/configs/phpunit-extension.xml
@@ -8,7 +8,11 @@
          beStrictAboutChangesToGlobalState="true">
 
   <php>
-    <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak" />
+      <!--
+        We allow 2 deprecations due to Drupal 8.x deprecated usage of Symfony
+        components. Drupal 9.x should only have 1.
+      -->
+      <env name="SYMFONY_DEPRECATIONS_HELPER" value="3" />
 
     <ini name="error_reporting" value="32767" />
     <ini name="memory_limit" value="-1" />


### PR DESCRIPTION
We allow 2 deprecations due to Drupal 8.x deprecated usage of Symfony
components. Drupal 9.x should only have 1.