### PR TITLE
Replace deprecated security-checker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "drupal/coder": "^8.3",
         "drupal/core": "^8.8 || ^9.0",
         "drupal/drupal-extension": "^4.1",
+        "enlightn/security-checker": "^1.4",
         "ergebnis/composer-normalize": "^2.11",
         "friendsoftwig/twigcs": "^4.0",
         "irstea/phpcpd-shim": "^6.0",
@@ -40,7 +41,6 @@
         "phpspec/prophecy": "^1.10",
         "phpstan/phpstan-deprecation-rules": "^0.12.5",
         "phpunit/phpunit": "^7.5 || ^8.4 || ^9",
-        "sensiolabs/security-checker": "^6.0",
         "symfony/phpunit-bridge": "^3.4 || ^5.2"
     },
     "minimum-stability": "dev",

--- a/configs/grumphp-extension.yml
+++ b/configs/grumphp-extension.yml
@@ -24,6 +24,7 @@ grumphp:
         - phpcs
         - phpmd
         - phpstan
+        - securitychecker_enlightn
         - twigcs
         - yamllint
     tests:
@@ -116,11 +117,8 @@ grumphp:
         - theme
     phpunit:
       config_file: phpunit.qa-drupal.xml
-    securitychecker:
+    securitychecker_enlightn:
       lockfile: ./composer.lock
-      format: ~
-      end_point: ~
-      timeout: ~
       run_always: false
     twigcs:
       path: 'templates'

--- a/configs/grumphp-site.yml
+++ b/configs/grumphp-site.yml
@@ -24,6 +24,7 @@ grumphp:
         - phpcs
         - phpmd
         - phpstan
+        - securitychecker_enlightn
         - twigcs
         - yamllint
     tests:
@@ -134,11 +135,8 @@ grumphp:
         - theme
     phpunit:
       config_file: phpunit.qa-drupal.xml
-    securitychecker:
+    securitychecker_enlightn:
       lockfile: ./composer.lock
-      format: ~
-      end_point: ~
-      timeout: ~
       run_always: false
     twigcs:
       path: 'web/themes/custom'


### PR DESCRIPTION
The SensioLabs Security Checker API is abandoned.

```
securitychecker
===============
The securitychecker task is discontinued by SensioLabs.
Please consider switching to one of the following tasks instead:
- securitychecker_enlightn (https://github.com/phpro/grumphp/blob/master/doc/tasks/securitychecker/enlightn.md)
- securitychecker_local (https://github.com/phpro/grumphp/blob/master/doc/tasks/securitychecker/local.md)
- securitychecker_symfony (https://github.com/phpro/grumphp/blob/master/doc/tasks/securitychecker/symfony.md)

```

See https://github.com/phpro/grumphp/blob/master/doc/tasks/securitychecker.md

Replaced by https://github.com/phpro/grumphp/blob/master/doc/tasks/securitychecker/enlightn.md

```
GrumPHP is sniffing your code!

Running tasks with priority 0!
==============================

Running task 1/1: securitychecker_enlightn... 
```