### PR TITLE
Update minimal requirement for grumphp

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "mglaman/phpstan-drupal": "^0.12.6",
         "nette/neon": "^3.2",
         "nielsdeblaauw/twigcs-a11y": "^0.2.0",
-        "phpro/grumphp-shim": "^1.1",
+        "phpro/grumphp-shim": "^1.3.1",
         "phpspec/prophecy": "^1.10",
         "phpstan/phpstan-deprecation-rules": "^0.12.5",
         "phpunit/phpunit": "^7.5 || ^8.4 || ^9",


### PR DESCRIPTION
The symfony security checker is no longer supported.