### PR TITLE
Depracate excludes_analyse

### DIFF
--- a/configs/phpstan.neon
+++ b/configs/phpstan.neon
@@ -12,7 +12,7 @@ parameters:
     - '#Method Drupal\\Core\\Form\\FormBuilderInterface::getForm\(\) invoked with#'
     - '#Access to an undefined property Drupal\\Core\\TypedData\\TypedDataInterface::\$#'
 
-  excludes_analyse:
+  excludePaths:
     - '*/node_modules/*'
 
   scanDirectories:


### PR DESCRIPTION
Configuration parameters excludes_analyse and excludePaths cannot be used at the same time.