### PR TITLE
Add .install files to the ignore list of phpcpd

### DIFF
--- a/configs/grumphp-site.yml
+++ b/configs/grumphp-site.yml
@@ -74,6 +74,7 @@ grumphp:
         - "*Test.php"
         - "*TestBase.php"
         - "*TestCase.php"
+        - "*.install"
       min_lines: 10
       triggered_by:
         - inc


### PR DESCRIPTION
They often contain schema definitions in hook_schema _and_ in the update hook 
where the table was added, triggering phpcpd.