### PR TITLE
Remove the install suffix for phpcpd

### DIFF
--- a/configs/grumphp-site.yml
+++ b/configs/grumphp-site.yml
@@ -78,7 +78,6 @@ grumphp:
       min_lines: 10
       triggered_by:
         - inc
-        - install
         - module
         - php
         - profile


### PR DESCRIPTION
It was added to the exclude list in the previous version, but it would appear 
that wasn't enough.