### PR TITLE
Fix failing CodeClimate checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All Notable changes to the **Quality Assurance - Drupal** package.
 
+## [1.5.1]
+
+### Changed
+
+- Add the *.install extension to the excluded files.
+
+### Fixed
+
+- Fix failing CodeClimate builds by changing `config/phpcs.xml` config file.
+
 ## [1.5.0]
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -166,3 +166,16 @@ Configure the paths to these files in PHPStorm:
   Set "Coding Standard" to "Custom" and set the path to `phpcs.qa-drupal.xml`.
 * Languages & Frameworks > PHP > Test Frameworks > Test Runner
   Set "Default configuration file" to `phpunit.qa-drupal.xml`.
+
+## CodeClimate
+
+Make sure that you use the beta channel for the PHPCodeSniffer plugin:
+
+```yaml
+plugins:
+  phpcodesniffer:
+    enabled: true
+    channel: beta
+    config:
+      standard: ".phpcs.xml"
+```

--- a/configs/phpcs.xml
+++ b/configs/phpcs.xml
@@ -6,8 +6,8 @@
   <exclude-pattern>*.min.css</exclude-pattern>
   <exclude-pattern>*.min.js</exclude-pattern>
 
-  <rule ref="./vendor/drupal/coder/coder_sniffer/Drupal"/>
-  <rule ref="./vendor/drupal/coder/coder_sniffer/DrupalPractice"></rule>
+  <rule ref="Drupal"/>
+  <rule ref="DrupalPractice"></rule>
 
   <!-- PSR-12 sniffs -->
   <rule ref="PSR12.Files.DeclareStatement"/>


### PR DESCRIPTION
Something has changed in the CodeClimate platform (update of the used
PHP version?) that breaks the CodeClimate tests.

### Change used PHPCodeSniffer version

The first error is:

> PHP Deprecated:  Array and string offset access syntax with curly
> braces is deprecated in
> /usr/src/app/vendor/squizlabs/php_codesniffer/CodeSniffer.php
> on line x
```

CodeClimate uses by default version 2.8.x
(see https://docs.codeclimate.com/docs/phpcodesniffer). The 3.6.x
version is available using the "beta channel".

Fix this by adding the channel to your `.codeclimate.yml` file:

```yaml
plugins:
  phpcodesniffer:
    enabled: true
    channel: beta
    config:
      standard: ".phpcs.xml"
```

### Change in .phpcs.xml

The `.phpcs.xml` file is fetched from this repository and added to the
project before CodeClimate starts running the checks and plugins. A new
error emerges after changing the PHPCodeSniffer version to 3.6.x:

> Exception: ERROR: Referenced sniff
> "./vendor/drupal/coder/coder_sniffer/Drupal" does not exist.

This is fixed in the `config/phpcs.xml` file that is fetched from this
repository. CodeClimate has support for the Drupal & DrupalPractice rule
sets so we don't need to refer to the local version:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<ruleset>
  <description>PHP CodeSniffer ruleset for Drupal.</description>

  <!-- Minified files don't have to comply with coding standards. -->
  <exclude-pattern>*.min.css</exclude-pattern>
  <exclude-pattern>*.min.js</exclude-pattern>

  <rule ref="Drupal"/>
  <rule ref="DrupalPractice"></rule>

  <!-- PSR-12 sniffs -->
  <rule ref="PSR12.Files.DeclareStatement"/>
</ruleset>
```